### PR TITLE
Update participants.js

### DIFF
--- a/src/parsers/body/participants.js
+++ b/src/parsers/body/participants.js
@@ -5,13 +5,10 @@ module.exports = elements => {
 
 	if (elements.attendees) {
 		const attendees = elements.attendees || [];
-		const transformedAttendees = attendees.map(attendee => {
-			return {
-				attendee: transformAttendee(attendee)
-			};
-		});
-
-		elCopy = Object.assign({}, elCopy, {attendees: transformedAttendees});
+		const transformedAttendees = attendees.map(attendee =>
+			transformAttendee(attendee)
+		);
+		elCopy = Object.assign({}, elCopy, {attendees: {attendee: transformedAttendees}});
 	}
 
 	return elCopy;


### PR DESCRIPTION
**How to reproduce the bug**
Use the following test case:
```javascript
// assumes requestBuilder with correct security context is present
const createMeeting =
	requestBuilder
		.metaData({
			confName: 'Sample Meeting',
		})
		.participants({
			attendees: [
				{
					name: 'Yolo Voe',
					email: 'subrat@lll.io',
				},
				{
					name: 'Bai Xiaochun',
					email: 'bai@xia.com',
				},
				{
					name: 'Benjamin Xu',
					email: 'ben@hamin.com',
				},
				{
					name: 'David Wang',
					email: 'david@wang.com',
				},
			]
		})
		.schedule({
			startDate: new Date(),
			openTime: 900,
			duration: 3,
			timeZoneID: 5,
		})
		.setService('CreateMeeting')
		.build()

console.log(createMeeting.payload); // check payload here

createMeeting
	.exec()
	.then((resp) => {
		parser.parseString(resp, (err, result) => {
			console.log(err);
			console.log(result);
			console.log(result['serv:message']['serv:header'][0]['serv:response']);
			console.log(result['serv:message']['serv:body'][0]['serv:bodyContent'][0]['meet:meetingkey'][0]);
			console.log(result['serv:message']['serv:body'][0]['serv:bodyContent'][0]['meet:iCalendarURL'][0]['serv:host'][0]);
			console.log(result['serv:message']['serv:body'][0]['serv:bodyContent'][0]['meet:iCalendarURL'][0]['serv:attendee'][0]);
	});
		console.log(typeof(resp));
		console.log(resp);
	});
```

To fix it, I have been using the following file (as provided in the PR):
```javascript
const transformAttendee = require('./partials/attendee');

module.exports = elements => {
	let elCopy = Object.assign({}, elements);

	if (elements.attendees) {
		const attendees = elements.attendees || [];
		const transformedAttendees = attendees.map(attendee =>
			transformAttendee(attendee)
		);
		elCopy = Object.assign({}, elCopy, {attendees: {attendee: transformedAttendees}});
	}

	return elCopy;
};
```

New test cases:
I suggest running `tests/create-meeting-test.js` as well as the code to reproduce the bug above.